### PR TITLE
[Build] Add managed OpenAssetIO dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ Pending tasks:
 
 ## Installation
 
-Presently, this is somewhat manual, and requires your own build of
-`openassetio` `v1.0.0-alpha.1` to be available in your python
-environment.
-
 ```shell
 git clone https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation
 cd OpenAssetIO-MediaCreation
@@ -34,8 +30,7 @@ pip install .
 
 ## Running the tests
 
-Assuming `openassetio` and `openassetio_mediacreation` packages are available in
-your python environment:
+To run the tests, after installing, simply run
 
 ```shell
 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2021-2022 The Foundry Visionmongers Ltd
+
+[project]
+name = "openassetio-mediacreation"
+version = "1.0.0a1"
+requires-python = ">=3.7"
+
+authors = [
+    { name = "Contributors to the OpenAssetIO project", email = "openassetio-discussion@lists.aswf.io" }
+]
+
+[project.urls]
+Source = "https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation"
+Issues = "https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation/issues"
+
 [tool.pylint.messages_control]
 
 [tool.pylint.format]

--- a/python/openassetio_mediacreation/trait/__init__.py
+++ b/python/openassetio_mediacreation/trait/__init__.py
@@ -11,10 +11,10 @@ to certain applications are grouped into modules by use.
 
 from typing import Union
 
-from openassetio import Trait
+from openassetio import TraitBase
 
 
-class TimelineTrait(Trait):
+class TimelineTrait(TraitBase):
     """
     This trait characterizes a collection of tracks that evaluate
     concurrently to form layers of references to media. Frequently used
@@ -25,7 +25,7 @@ class TimelineTrait(Trait):
     kId = "timeline"
 
 
-class TrackTrait(Trait):
+class TrackTrait(TraitBase):
     """
     This trait characterizes a lane or collection of media, arranged
     temporally such that only a single item in the collection is active
@@ -36,7 +36,7 @@ class TrackTrait(Trait):
     kId = "track"
 
 
-class ClipTrait(Trait):
+class ClipTrait(TraitBase):
     """
     This trait characterizes the use of some range of external media,
     commonly on a track or timeline. Frequently used in non-linear
@@ -56,13 +56,13 @@ class ClipTrait(Trait):
         """
         if not isinstance(name, str):
             raise TypeError("name must be a string")
-        self._specification.setTraitProperty(self.kId, self.__kName, name)
+        self._data.setTraitProperty(self.kId, self.__kName, name)
 
     def getName(self, defaultValue=None) -> Union[str, None]:
         """
         Returns the name of the clip or the defaultValue.
         """
-        value = self._specification.getTraitProperty(self.kId, self.__kName)
+        value = self._data.getTraitProperty(self.kId, self.__kName)
         if value is None:
             return defaultValue
         elif not isinstance(value, str):

--- a/python/openassetio_mediacreation/trait/entity.py
+++ b/python/openassetio_mediacreation/trait/entity.py
@@ -7,10 +7,10 @@ characteristics of an entity for resolve or registration.
 
 from typing import Union
 
-from openassetio import Trait
+from openassetio import TraitBase
 
 
-class LocatableContentTrait(Trait):
+class LocatableContentTrait(TraitBase):
     """
     This trait characterizes an entity whose data is persisted externally
     to the API through data accessible via a valid URL.
@@ -33,7 +33,7 @@ class LocatableContentTrait(Trait):
         """
         if not isinstance(contentLocation, str):
             raise TypeError("contentLocation must be a string")
-        self._specification.setTraitProperty(self.kId, self.__kLocation, contentLocation)
+        self._data.setTraitProperty(self.kId, self.__kLocation, contentLocation)
 
     def getLocation(self, defaultValue=None) -> Union[str, None]:
         """
@@ -42,7 +42,7 @@ class LocatableContentTrait(Trait):
 
         This is a URL, and so special characters will be encoded.
         """
-        value = self._specification.getTraitProperty(self.kId, self.__kLocation)
+        value = self._data.getTraitProperty(self.kId, self.__kLocation)
         if value is None:
             return defaultValue
         elif not isinstance(value, str):

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="openassetio_mediacreation",
-    version="0.0.0",
     package_dir={"": "python"},
     packages=find_packages(where="python"),
-    python_requires=">=3.9.1",
+    install_requires=["openassetio>=1.0.0a6"]
 )

--- a/tests/python/openassetio_mediacreation/trait/test___init__.py
+++ b/tests/python/openassetio_mediacreation/trait/test___init__.py
@@ -10,7 +10,7 @@ Basic tests for common entity traits.
 
 import pytest
 
-from openassetio import Specification
+from openassetio import TraitsData
 
 ##
 ## TimelineTrait
@@ -49,72 +49,72 @@ class Test_ClipTrait:
 
 
 class Test_ClipTrait_name:
-    def test_when_spec_does_not_have_clip_trait_then_raises_IndexError(
-        self, an_empty_specification
+    def test_when_traitsData_does_not_have_clip_trait_then_raises_IndexError(
+        self, an_empty_traitsData
     ):
-        trait = ClipTrait(an_empty_specification)
+        trait = ClipTrait(an_empty_traitsData)
         with pytest.raises(IndexError):
             trait.getName()
 
-    def test_when_name_property_is_set_then_returns_name(self, a_clip_specification):
+    def test_when_name_property_is_set_then_returns_name(self, a_clip_traitsData):
         expected = "yet another name"
-        a_clip_specification.setTraitProperty(ClipTrait.kId, "name", expected)
-        assert ClipTrait(a_clip_specification).getName() == expected
+        a_clip_traitsData.setTraitProperty(ClipTrait.kId, "name", expected)
+        assert ClipTrait(a_clip_traitsData).getName() == expected
 
-    def test_when_name_property_not_set_then_returns_None(self, a_clip_specification):
-        assert ClipTrait(a_clip_specification).getName() is None
+    def test_when_name_property_not_set_then_returns_None(self, a_clip_traitsData):
+        assert ClipTrait(a_clip_traitsData).getName() is None
 
     def test_when_name_property_is_not_set_and_default_provided_then_returns_default(
-        self, a_clip_specification
+        self, a_clip_traitsData
     ):
         default = "a default name"
-        actual = ClipTrait(a_clip_specification).getName(defaultValue=default)
+        actual = ClipTrait(a_clip_traitsData).getName(defaultValue=default)
         assert actual == default
 
     def test_when_name_property_has_wrong_type_and_no_default_provided_then_raises_TypeError(
-        self, a_clip_specification
+        self, a_clip_traitsData
     ):
-        a_clip_specification.setTraitProperty(ClipTrait.kId, "name", 123)
+        a_clip_traitsData.setTraitProperty(ClipTrait.kId, "name", 123)
         with pytest.raises(TypeError) as err:
-            assert ClipTrait(a_clip_specification).getName()
+            assert ClipTrait(a_clip_traitsData).getName()
         assert str(err.value) == "Invalid stored value type: '123' [int]"
 
     def test_when_name_property_has_wrong_value_type_and_default_provided_then_returns_default(
-        self, a_clip_specification
+        self, a_clip_traitsData
     ):
-        a_clip_specification.setTraitProperty(ClipTrait.kId, "name", 123)
-        trait = ClipTrait(a_clip_specification)
+        a_clip_traitsData.setTraitProperty(ClipTrait.kId, "name", 123)
+        trait = ClipTrait(a_clip_traitsData)
         default = "a default name"
         assert trait.getName(defaultValue=default) == default
 
 
 class Test_ClipTrait_setName:
-    def test_when_spec_does_not_have_clip_trait_then_raises_IndexError(
-        self, an_empty_specification
+    def test_when_traitsData_does_not_have_clip_trait_then_trait_is_added(
+        self, an_empty_traitsData
     ):
-        trait = ClipTrait(an_empty_specification)
-        with pytest.raises(IndexError):
-            trait.setName("a name")
+        trait = ClipTrait(an_empty_traitsData)
+        trait.setName("a name")
+        assert an_empty_traitsData.hasTrait(ClipTrait.kId)
 
-    def test_when_set_then_expected_trait_property_is_set(self, a_clip_specification):
-        trait = ClipTrait(a_clip_specification)
+    def test_when_set_then_expected_trait_property_is_set(self, a_clip_traitsData):
+        trait = ClipTrait(a_clip_traitsData)
         expected = "another name"
         trait.setName(expected)
-        actual = a_clip_specification.getTraitProperty(ClipTrait.kId, "name")
+        actual = a_clip_traitsData.getTraitProperty(ClipTrait.kId, "name")
         assert actual == expected
 
-    def test_when_name_type_is_wrong_then_TypeError_is_raised(self, a_clip_specification):
-        trait = ClipTrait(a_clip_specification)
+    def test_when_name_type_is_wrong_then_TypeError_is_raised(self, a_clip_traitsData):
+        trait = ClipTrait(a_clip_traitsData)
         with pytest.raises(TypeError) as err:
             trait.setName(123)
         assert str(err.value) == "name must be a string"
 
 
 @pytest.fixture
-def an_empty_specification():
-    return Specification(set())
+def an_empty_traitsData():
+    return TraitsData()
 
 
 @pytest.fixture
-def a_clip_specification():
-    return Specification({ClipTrait.kId})
+def a_clip_traitsData():
+    return TraitsData({"clip"})

--- a/tests/python/openassetio_mediacreation/trait/test_entity.py
+++ b/tests/python/openassetio_mediacreation/trait/test_entity.py
@@ -10,12 +10,11 @@ Basic tests for entity traits.
 
 import pytest
 
-from openassetio import Specification
+from openassetio import TraitsData
 
 ##
 ## LocatableContentTrait
 ##
-
 from openassetio_mediacreation.trait.entity import LocatableContentTrait
 
 
@@ -25,88 +24,88 @@ class Test_LocatableContentTrait:
 
 
 class Test_LocatableContentTrait_location:
-    def test_when_spec_does_not_have_locatableContent_trait_then_raises_IndexError(
-        self, an_empty_specification
+    def test_when_traitsData_does_not_have_locatableContent_trait_then_raises_IndexError(
+        self, an_empty_traitsData
     ):
-        trait = LocatableContentTrait(an_empty_specification)
+        trait = LocatableContentTrait(an_empty_traitsData)
         with pytest.raises(IndexError):
             trait.getLocation()
 
     def test_when_location_property_is_set_then_returns_location(
-        self, a_locatableContent_specification
+        self, a_locatableContent_traitsData
     ):
         expected = "yet another location"
-        a_locatableContent_specification.setTraitProperty(
+        a_locatableContent_traitsData.setTraitProperty(
             LocatableContentTrait.kId, "location", expected
         )
-        assert LocatableContentTrait(a_locatableContent_specification).getLocation() == expected
+        assert LocatableContentTrait(a_locatableContent_traitsData).getLocation() == expected
 
     def test_when_location_property_not_set_then_returns_None(
-        self, a_locatableContent_specification
+        self, a_locatableContent_traitsData
     ):
-        assert LocatableContentTrait(a_locatableContent_specification).getLocation() is None
+        assert LocatableContentTrait(a_locatableContent_traitsData).getLocation() is None
 
     def test_when_location_property_is_not_set_and_default_provided_then_returns_default(
-        self, a_locatableContent_specification
+        self, a_locatableContent_traitsData
     ):
         default = "a default location"
-        actual = LocatableContentTrait(a_locatableContent_specification).getLocation(
+        actual = LocatableContentTrait(a_locatableContent_traitsData).getLocation(
             defaultValue=default
         )
         assert actual == default
 
     def test_when_location_property_has_wrong_type_and_no_default_provided_then_raises_TypeError(
-        self, a_locatableContent_specification
+        self, a_locatableContent_traitsData
     ):
-        a_locatableContent_specification.setTraitProperty(
+        a_locatableContent_traitsData.setTraitProperty(
             LocatableContentTrait.kId, "location", 123
         )
         with pytest.raises(TypeError) as err:
-            assert LocatableContentTrait(a_locatableContent_specification).getLocation()
+            assert LocatableContentTrait(a_locatableContent_traitsData).getLocation()
         assert str(err.value) == "Invalid stored value type: '123' [int]"
 
     def test_when_location_property_has_wrong_value_type_and_default_provided_then_returns_default(
-        self, a_locatableContent_specification
+        self, a_locatableContent_traitsData
     ):
-        a_locatableContent_specification.setTraitProperty(
+        a_locatableContent_traitsData.setTraitProperty(
             LocatableContentTrait.kId, "location", 123
         )
-        trait = LocatableContentTrait(a_locatableContent_specification)
+        trait = LocatableContentTrait(a_locatableContent_traitsData)
         default = "a default location"
         assert trait.getLocation(defaultValue=default) == default
 
 
 class Test_LocatableContentTrait_setLocation:
-    def test_when_spec_does_not_have_locatableContent_trait_then_raises_IndexError(
-        self, an_empty_specification
+    def test_when_traitsData_does_not_have_locatableContent_trait_then_trait_is_added(
+        self, an_empty_traitsData
     ):
-        trait = LocatableContentTrait(an_empty_specification)
-        with pytest.raises(IndexError):
-            trait.setLocation("a location")
+        trait = LocatableContentTrait(an_empty_traitsData)
+        trait.setLocation("a location")
+        assert an_empty_traitsData.hasTrait(LocatableContentTrait.kId)
 
-    def test_when_set_then_expected_trait_property_is_set(self, a_locatableContent_specification):
-        trait = LocatableContentTrait(a_locatableContent_specification)
+    def test_when_set_then_expected_trait_property_is_set(self, a_locatableContent_traitsData):
+        trait = LocatableContentTrait(a_locatableContent_traitsData)
         expected = "another location"
         trait.setLocation(expected)
-        actual = a_locatableContent_specification.getTraitProperty(
+        actual = a_locatableContent_traitsData.getTraitProperty(
             LocatableContentTrait.kId, "location"
         )
         assert actual == expected
 
     def test_when_location_type_is_wrong_then_TypeError_is_raised(
-        self, a_locatableContent_specification
+        self, a_locatableContent_traitsData
     ):
-        trait = LocatableContentTrait(a_locatableContent_specification)
+        trait = LocatableContentTrait(a_locatableContent_traitsData)
         with pytest.raises(TypeError) as err:
             trait.setLocation(123)
         assert str(err.value) == "contentLocation must be a string"
 
 
 @pytest.fixture
-def an_empty_specification():
-    return Specification(set())
+def an_empty_traitsData():
+    return TraitsData()
 
 
 @pytest.fixture
-def a_locatableContent_specification():
-    return Specification({LocatableContentTrait.kId})
+def a_locatableContent_traitsData():
+    return TraitsData({"locatableContent"})


### PR DESCRIPTION
Closes #9 

Use the PyPI version of OpenAssetIO as the dependency, rather than requiring a manual build.
In prelude to moving traitgen over and automatically generating these traits.