### PR TITLE
MediaCreation Publish PyPI

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The Foundry Visionmongers Ltd#
+
+name: Build Wheels
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  pull_request:
+
+concurrency:
+  # Shared with `deploy-pypi`.
+  group: wheel-${{ github.ref }}
+  # Cancel any in-progress build or publish.
+  cancel-in-progress: true
+
+jobs:
+  build_wheels:
+    name: Build wheel
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+
+      - name: Build wheels
+        run: pip wheel --no-deps --wheel-dir wheelhouse .
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: openassetio-mediacreation-wheels
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The Foundry Visionmongers Ltd
+
+name: Deploy PyPI
+
+concurrency:
+  # Shared with `build-wheels`.
+  group: wheel-${{ github.ref }}
+  # Allow `build-wheels` to finish.
+  cancel-in-progress: false
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish_testpypi:
+    name: Publish distribution 📦 to TestPyPI
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download wheels from commit ${{ github.sha }}
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          commit: ${{ github.sha }}
+          name: openassetio-mediacreation-wheels
+          path: dist
+
+      - name: Upload to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_ACCESS_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+  publish_pypi:
+    name: Publish distribution 📦 to PyPI
+    needs: publish_testpypi
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download wheels from commit ${{ github.sha }}
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          commit: ${{ github.sha }}
+          name: openassetio-mediacreation-wheels
+          path: dist
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Included are several well-known Traits and Specifications for use in
 OpenAssetIO hosts and managers. For more information on this mechanism,
 see the [OpenAssetIO docs](https://thefoundryvisionmongers.github.io/OpenAssetIO/).
 
+MediaCreation is a fully generated component,
+[openassetio-traitgen](https://github.com/OpenAssetIO/OpenAssetIO-TraitGen)
+is used to generate trait implementations based on [traits.yml](traits.yml)
+
 ## Project status
 
 These initial incarnations of traits/specifications serve as
@@ -24,9 +28,7 @@ Pending tasks:
 ## Installation
 
 ```shell
-git clone https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation
-cd OpenAssetIO-MediaCreation
-pip install .
+pip install openassetio-mediacreation
 ```
 
 During installation, [openassetio-traitgen](https://github.com/OpenAssetIO/OpenAssetIO-TraitGen)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Included are several well-known Traits and Specifications for use in
 OpenAssetIO hosts and managers. For more information on this mechanism,
 see the [OpenAssetIO docs](https://thefoundryvisionmongers.github.io/OpenAssetIO/).
 
-MediaCreation is a fully generated component,
+MediaCreation is an automatically generated Python package,
 [openassetio-traitgen](https://github.com/OpenAssetIO/OpenAssetIO-TraitGen)
 is used to generate trait implementations based on [traits.yml](traits.yml)
 
@@ -28,11 +28,8 @@ Pending tasks:
 ## Installation
 
 ```shell
-pip install openassetio-mediacreation
+python -m pip install openassetio-mediacreation
 ```
-
-During installation, [openassetio-traitgen](https://github.com/OpenAssetIO/OpenAssetIO-TraitGen)
-will be used to generate trait implementations based on [traits.yml](traits.yml)
 
 ## Running the tests
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-v1.0.0-alpha.x
+v1.0.0-alpha.2
 --------------
 
 ### Breaking changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openassetio-mediacreation"
-version = "1.0.0a1"
+version = "1.0.0a2"
 requires-python = ">=3.7"
 dependencies = ["openassetio>=1.0.0a6"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,41 @@ authors = [
     { name = "Contributors to the OpenAssetIO project", email = "openassetio-discussion@lists.aswf.io" }
 ]
 
+keywords = ["openassetio", "mediacreation", "trait"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[project.readme]
+text = """\
+# OpenAssetIO-MediaCreation
+
+OpenAssetIO extensions for use in Media Creation
+
+> Note: This repository is currently in a pre-alpha state, and so should
+> not be used for any production critical applications.
+
+Included are several well-known Traits and Specifications for use in
+OpenAssetIO hosts and managers. For more information on this mechanism,
+see the [OpenAssetIO docs](https://thefoundryvisionmongers.github.io/OpenAssetIO/).
+"""
+content-type = "text/markdown"
+
 dependencies = ["openassetio>=1.0.0a6"]
 
 [tool.setuptools]
 packages = ["openassetio_mediacreation"]
 
 [project.urls]
+OpenAssetIO = "https://github.com/OpenAssetIO/OpenAssetIO"
 Source = "https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation"
 Issues = "https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation/issues"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ build-backend = "setuptools.build_meta"
 name = "openassetio-mediacreation"
 version = "1.0.0a1"
 requires-python = ">=3.7"
+dependencies = ["openassetio>=1.0.0a6"]
 
 authors = [
     { name = "Contributors to the OpenAssetIO project", email = "openassetio-discussion@lists.aswf.io" }


### PR DESCRIPTION
Closes #11 

Provides the standard build wheels and publish process for MediaCreation.
Have updated to alpha 2 so a publish can be performed strait away

TestPyPI publish can be perused here : https://test.pypi.org/project/openassetio-mediacreation/1.0.0a1.dev0/