### PR TITLE
Migrate managementPolicy traits from OpenAssetIO

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,14 @@ v1.0.0-alpha.x
   This was removed from the OpenAssetIO core API.
   [#717](https://github.com/OpenAssetIO/OpenAssetIO/issues/717)
 
+- Adds the `ResolvesFutureEntities` management policy trait, that can be
+  used to indicate that a manager is capable of resolving the specified
+  trait set for entities that don't exist yet. This supersedes the old
+  `WillManagePathTrait`, that was deprecated and subsequently remove
+  from OpenAssetIO core API following the switch from the old 'primary
+  string and attributes' approach to composed traits.
+  [#717](https://github.com/OpenAssetIO/OpenAssetIO/issues/717)
+
 
 v1.0.0-alpha.2
 --------------

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,11 @@ v1.0.0-alpha.x
   [#717](https://github.com/OpenAssetIO/OpenAssetIO/issues/717)
 
 
+### Improvements
+
+- Added usage information to all traits.
+
+
 v1.0.0-alpha.2
 --------------
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,17 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+
+### New features
+
+- Adds the `Managed` management policy trait, that indicates that a
+  manager wishes to manage data matching the specified trait set.
+  This was removed from the OpenAssetIO core API.
+  [#717](https://github.com/OpenAssetIO/OpenAssetIO/issues/717)
+
+
 v1.0.0-alpha.2
 --------------
 

--- a/tests/python/openassetio_mediacreation/test_imports.py
+++ b/tests/python/openassetio_mediacreation/test_imports.py
@@ -46,3 +46,6 @@ class Test_trait_imports:
 
     def test_importing_LocatableContentTrait_succeeds(self):
         from openassetio_mediacreation.traits.content import LocatableContentTrait
+
+    def test_importing_ManagedTrait_succeeds(self):
+        from openassetio_mediacreation.traits.managementPolicy import ManagedTrait

--- a/tests/python/openassetio_mediacreation/test_imports.py
+++ b/tests/python/openassetio_mediacreation/test_imports.py
@@ -49,3 +49,6 @@ class Test_trait_imports:
 
     def test_importing_ManagedTrait_succeeds(self):
         from openassetio_mediacreation.traits.managementPolicy import ManagedTrait
+
+    def test_importing_ResolvesFutureEntitiesTrait_succeeds(self):
+        from openassetio_mediacreation.traits.managementPolicy import ResolvesFutureEntitiesTrait

--- a/traits.yml
+++ b/traits.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../python/openassetio_traitgen/schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/OpenAssetIO/OpenAssetIO-TraitGen/main/python/openassetio_traitgen/schema.json
 # yamllint disable-line rule:document-start
 package: openassetio-mediacreation
 

--- a/traits.yml
+++ b/traits.yml
@@ -15,6 +15,9 @@ traits:
           concurrently to form layers of references to media. Frequently
           used in non-linear editing environments such as Video and
           Audio post production tools.
+        usage:
+          - entity
+          - locale
 
       Track:
         description: >
@@ -23,6 +26,9 @@ traits:
           collection is active at any given time. Frequently used in
           non-linear editing environments such as Video and Audio post
           production tools.
+        usage:
+          - entity
+          - locale
 
       Clip:
         description: >
@@ -34,6 +40,9 @@ traits:
 
           TODO(TC) Define any additional properties, and companion
           traits such as 'frameRange' and 'handles'.
+        usage:
+          - entity
+          - locale
         properties:
           name:
             type: string
@@ -53,6 +62,8 @@ traits:
           of the entity's content for the current process environment
           - considering platform, host, etc. Location is in the form
           of a URL.
+        usage:
+          - entity
         properties:
           location:
             type: string

--- a/traits.yml
+++ b/traits.yml
@@ -38,6 +38,7 @@ traits:
           name:
             type: string
             description: The name of the clip.
+
   content:
     description: Traits related to abstract content.
     members:
@@ -61,3 +62,44 @@ traits:
 
               This must be a valid URL so special characters need to
               be encoded.
+
+  managementPolicy:
+    description: Traits used in a Manager's managementPolicy response.
+    members:
+      Managed:
+        description: >
+          A trait indicating that the data matching the supplied trait set
+          is handled by the manager.
+
+
+          There are three possible policies determined by
+          applying/querying this trait:
+          * If the response is not imbued with this trait, then the
+            Manager has no interest in participating in the management of
+            entities that match the queried trait set, for either read or
+            write.
+          * If the response is imbued with this trait, but the "exclusive"
+            property is not set, or set to False, then the Manager would
+              like the opportunity to manage the data, but the user should
+              still be presented with standard Host UI for the type as an
+              option.
+            * If  the "exclusive" property is set to true, then the Manager
+              takes exclusive control over data with the queried trait set,
+              and any standard host interfaces etc should be suppressed.
+        usage:
+          - managementPolicy
+        properties:
+          exclusive:
+            type: boolean
+            description: >
+              Determines if the manager exclusively handles data matching
+              the supplied trait set.
+
+
+              If True, then standard host contols should be disabled
+              in favour of manager delegated UI. For example, file system
+              browsers when determining where to load/save data.
+
+
+              If False, then standard host controls can be presented in
+              addition to any custom manager UI.

--- a/traits.yml
+++ b/traits.yml
@@ -103,3 +103,25 @@ traits:
 
               If False, then standard host controls can be presented in
               addition to any custom manager UI.
+
+      ResolvesFutureEntities:
+        description: >
+          A trait indicating a manager can potentially resolve the
+          supplied trait set for future entities.
+
+
+          If not imbued, the manager is not capable of determining data
+          in advance for new entities, and is only capable of resolving
+          traits for exising ones.
+
+
+          An example of this would be the ability to resolve a
+          LocatableContentTrait in advance, to determine where new data
+          should be written. When this trait imbued in the
+          managementPolicy response, a host may attempt to resolve the
+          locatableContent trait of a working entity reference supplied by
+          preflight in order to determine a suitable output path before
+          work is done. In its absence, a host must use alternate means to
+          determine a suitable output location.
+        usage:
+          - managementPolicy


### PR DESCRIPTION
Adds traits recently removed from OpenAssetIO and a few other minor improvements noticed on the way.

Closes https://github.com/OpenAssetIO/OpenAssetIO/issues/717