### PR TITLE
[Docs] Update test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,15 @@ python -m pip install openassetio-mediacreation
 
 ## Running the tests
 
-To run the tests, after installing, simply run
+To run the tests, on a local development checkout, you can install
+the package with pip, then run `pytest`.
+
+Note, editable installs are not supported as the package is entirely
+auto-generated from the traits YAML.
 
 ```shell
+python -m pip install .
+python -m pip install pytest
 pytest
 ```
 


### PR DESCRIPTION
The instructions said 'after installing', which you could do from a pip install, but I'd imagine the usual use case is for developers?