### PR TITLE
[Examples] Add proxy workflow sketch

### DIFF
--- a/examples/proxy_workflows/README.md
+++ b/examples/proxy_workflows/README.md
@@ -43,7 +43,8 @@ The sketch models a contrived workflow, whereby you provide it with a
 single entity reference, and it queries any alternate image sequence
 representations. Any discovered references are printed out to the shell.
 
-The included BAL library is very simple. It contains an plate:
+The included BAL library is very simple. It contains some footage from
+on set.
 
 - `bal:///plate/original`
 
@@ -57,7 +58,7 @@ You can use the script with any of these references to explore the
 available alternatives, eg:
 
 ```shell
-python ./proxies.py bal://plate/proxy/1080
+python ./proxies.py bal:///plate/proxy/1080
 ```
 
 This should show you info about the orginal, as well as other available

--- a/examples/proxy_workflows/README.md
+++ b/examples/proxy_workflows/README.md
@@ -1,0 +1,119 @@
+# Proxy Workflows sketch
+
+This folder contains an example workflow, that demonstrates how
+OpenAssetIO's `getRelatedReferences` can be used to query alternate
+representations of an image sequence. Either in the form of the
+"original" version, or some proxy representation.
+
+This workflow could be used to rebuild an EDL with alternate versions,
+for example, a multi-ref OTIO file.
+
+
+## Setup
+
+Assuming linux/macOS, and the working directory is a checkout of this
+codebase.
+
+
+```shell
+# Make a venv as this is all heavily experimental
+python -m venv .venv
+. ./.venv/bin/activate
+
+# Install MediaCreation itself
+python -m pip install .
+
+# Install the requirements of the sketch
+python -m pip install -r examples/proxy_workflows/requirements.txt
+```
+
+If you now switch the example directory we can make use of the included
+sample data.
+
+```shell
+cd examples/proxy_workflows
+
+# Tell OpenAssetIO to use the preconfigured BAL library
+export OPENASSETIO_DEFAULT_CONFIG=bal_proxies_openassetio_config.toml
+```
+
+## Usage
+
+The sketch models a contrived workflow, whereby you provide it with a
+single entity reference, and it queries any alternate image sequence
+representations. Any discovered references are printed out to the shell.
+
+The included BAL library is very simple. It contains an plate:
+
+- `bal:///plate/original`
+
+The plate has three proxy alternatives of different sizes:
+
+ - `bal:///plate/proxy/1080`
+ - `bal:///plate/proxy/720`
+ - `bal:///plate/proxy/576`
+
+You can use the script with any of these references to explore the
+available alternatives, eg:
+
+```shell
+python ./proxies.py bal://plate/proxy/1080
+```
+
+This should show you info about the orginal, as well as other available
+proxies:
+
+```shell
+$ python ./proxies.py bal:///plate/proxy/1080
+Representations for: bal:///plate/proxy/1080
+
+Original:
+
+bal:///plate/original
+  - openassetio-mediacreation:content.LocatableContent:
+      location: file:///media/plate.orig.%2504d.exr
+  - openassetio-mediacreation:time.FrameRanged:
+      startFrame: 1001
+      endFrame: 1351
+  - openassetio-mediacreation:image.Image
+  - openassetio-mediacreation:image.OCIOColorManaged:
+      colorspace: ADX10
+  - openassetio-mediacreation:image.Raster:
+      width: 4096
+      height: 2160
+
+Proxies:
+
+ bal:///plate/proxy/720
+  - openassetio-mediacreation:content.LocatableContent:
+      location: file:///media/plate.720p.mov
+  - openassetio-mediacreation:time.FrameRanged:
+      startFrame: 1001
+      endFrame: 1351
+  - openassetio-mediacreation:image.Image
+  - openassetio-mediacreation:image.OCIOColorManaged:
+      colorspace: Rec.709-sRGB
+  - openassetio-mediacreation:image.Raster:
+      width: 1920
+      height: 720
+  - openassetio-mediacreation:representation.Proxy:
+      label: Half HD (720p)
+      scaleRatio: 0.333
+
+ bal:///plate/proxy/576
+  - openassetio-mediacreation:content.LocatableContent:
+      location: file:///media/plate.PAL.mov
+  - openassetio-mediacreation:time.FrameRanged:
+      startFrame: 1001
+      endFrame: 1351
+  - openassetio-mediacreation:image.Image
+  - openassetio-mediacreation:image.OCIOColorManaged:
+      colorspace: Rec.709-sRGB
+  - openassetio-mediacreation:image.Raster:
+      width: 720
+      pixelAspectRatio: 1.422
+      height: 576
+  - openassetio-mediacreation:representation.Proxy:
+      label: PAL (anamorphic)
+      scaleRatio: 0.267
+```

--- a/examples/proxy_workflows/bal_proxies.json
+++ b/examples/proxy_workflows/bal_proxies.json
@@ -1,0 +1,149 @@
+{
+	"$schema": "https://raw.githubusercontent.com/OpenAssetIO/OpenAssetIO/main/resources/examples/manager/BasicAssetLibrary/schema.json",
+	"entities": {
+		"plate/original": {
+			"versions": [
+				{
+					"traits": {
+						"openassetio-mediacreation:image.Image": {},
+						"openassetio-mediacreation:content.LocatableContent": {
+							"location": "file:///media/plate.orig.%2504d.exr"
+						},
+						"openassetio-mediacreation:image.Raster": {
+							"height": 2160,
+							"width": 4096
+						},
+						"openassetio-mediacreation:image.OCIOColorManaged": {
+							"colorspace": "ADX10"
+						},
+						"openassetio-mediacreation:time.FrameRanged": {
+							"startFrame": 1001,
+							"endFrame": 1351
+						}
+					}
+				}
+			],
+			"relations": [
+				{
+					"traits": { "openassetio-mediacreation:representation.Proxy": {} },
+					"entities": [ "plate/proxy/1080", "plate/proxy/720", "plate/proxy/576" ]
+				}
+			]
+		},
+		"plate/proxy/1080": {
+			"versions": [
+				{
+					"traits": {
+						"openassetio-mediacreation:image.Image": {},
+						"openassetio-mediacreation:content.LocatableContent": {
+							"location": "file:///media/plate.1080p.mov"
+						},
+						"openassetio-mediacreation:image.Raster": {
+							"height": 1080,
+							"width": 1920
+						},
+						"openassetio-mediacreation:image.OCIOColorManaged": {
+							"colorspace": "Rec.709-sRGB"
+						},
+						"openassetio-mediacreation:time.FrameRanged": {
+							"startFrame": 1001,
+							"endFrame": 1351
+						},
+						"openassetio-mediacreation:representation.Proxy": {
+							"scaleRatio": 0.5,
+							"label": "Full HD (1080p)"
+						}
+					}
+				}
+			],
+			"relations": [
+				{
+					"traits": { "openassetio-mediacreation:representation.Proxy": {} },
+					"entities": [ "plate/proxy/720", "plate/proxy/576" ]
+				},
+				{
+					"traits": { "openassetio-mediacreation:representation.Original": {} },
+					"entities": [ "plate/original" ]
+				}
+			]
+		},
+		"plate/proxy/720": {
+			"versions": [
+				{
+					"traits": {
+						"openassetio-mediacreation:image.Image": {},
+						"openassetio-mediacreation:content.LocatableContent": {
+							"location": "file:///media/plate.720p.mov"
+						},
+						"openassetio-mediacreation:image.Raster": {
+							"height": 720,
+							"width": 1920
+						},
+						"openassetio-mediacreation:image.OCIOColorManaged": {
+							"colorspace": "Rec.709-sRGB"
+						},
+						"openassetio-mediacreation:time.FrameRanged": {
+							"startFrame": 1001,
+							"endFrame": 1351
+						},
+						"openassetio-mediacreation:representation.Proxy": {
+							"scaleRatio": 0.333,
+							"label": "Half HD (720p)"
+						}
+					}
+				}
+			],
+			"relations": [
+				{
+					"traits": { "openassetio-mediacreation:representation.Proxy": {} },
+					"entities": [ "plate/proxy/1080", "plate/proxy/576" ]
+				},
+				{
+					"traits": { "openassetio-mediacreation:representation.Original": {} },
+					"entities": [ "plate/original" ]
+				}
+			]
+		},
+		"plate/proxy/576": {
+			"versions": [
+				{
+					"traits": {
+						"openassetio-mediacreation:image.Image": {},
+						"openassetio-mediacreation:content.LocatableContent": {
+							"location": "file:///media/plate.PAL.mov"
+						},
+						"openassetio-mediacreation:image.Raster": {
+							"height": 576,
+							"width": 720,
+							"pixelAspectRatio": 1.422
+				  
+						},
+						"openassetio-mediacreation:image.OCIOColorManaged": {
+							"colorspace": "Rec.709-sRGB"
+						},
+						"openassetio-mediacreation:time.FrameRanged": {
+							"startFrame": 1001,
+							"endFrame": 1351
+						},
+						"openassetio-mediacreation:representation.Proxy": {
+							"scaleRatio": 0.267,
+							"label": "PAL (anamorphic)"
+						}
+					}
+				}
+			],
+			"relations": [
+				{
+					"traits": { "openassetio-mediacreation:representation.Proxy": {} },
+					"entities": [ "plate/proxy/1080", "plate/proxy/720" ]
+				},
+				{
+					"traits": { "openassetio-mediacreation:representation.Original": {} },
+					"entities": [ "plate/original" ]
+				}
+			]
+		}
+
+
+	}
+  }

--- a/examples/proxy_workflows/bal_proxies_openassetio_config.toml
+++ b/examples/proxy_workflows/bal_proxies_openassetio_config.toml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The Foundry Visionmongers Ltd
+
+[manager]
+identifier = "org.openassetio.examples.manager.bal"
+
+[manager.settings]
+library_path = "bal_proxies.json"

--- a/examples/proxy_workflows/proxies.py
+++ b/examples/proxy_workflows/proxies.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The Foundry Visionmongers Ltd
+
+"""
+A WIP sketch of how OpenAssetIO can be used to discover alternate
+representations of an Entity, for example - proxy versions of image
+sequences.
+"""
+
+import sys
+
+from typing import Dict, List, NamedTuple, Set
+
+from openassetio import BatchElementError, Context, EntityReference, TraitsData
+from openassetio.exceptions import EntityResolutionError
+from openassetio.hostApi import HostInterface, Manager, ManagerFactory
+from openassetio.log import ConsoleLogger, SeverityFilter
+from openassetio.pluginSystem import PythonPluginSystemManagerImplementationFactory
+
+from openassetio_mediacreation.traits.representation import OriginalTrait, ProxyTrait
+from openassetio_mediacreation.specifications.locale import ExampleCodeCLISpecification
+from openassetio_mediacreation.specifications.image import RasterImageSequenceSpecification
+
+
+class ProxyWorkflowsHost(HostInterface):
+    """
+    The class that identifies this script to OpenAssetIO.
+    """
+
+    def identifier(self):
+        return "org.openassetio.mediacreation.examples.proxyWorkflows.host"
+
+    def displayName(self):
+        return "Proxy Workflows Demo"
+
+
+class EntityRepresentations(NamedTuple):
+    """
+    Information about alternate representations of some entity.
+    """
+
+    source: EntityReference
+    original: EntityReference
+    proxies: List[EntityReference]
+    # EntityReferences aren't currently hashable, see:
+    #   https://github.com/OpenAssetIO/OpenAssetIO/issues/802
+    data: Dict[str, TraitsData]
+
+
+def get_all_representations(
+    entity_reference: EntityReference, entity_trait_set: Set, manager: Manager, context: Context
+) -> EntityRepresentations:
+    """
+    Gets all available representations (original/proxy) for some Entity.
+    """
+
+    # Make sure we're using the correct context
+    context.access = context.Access.kRead
+
+    # We use the getRelatedReferences mechanism to ask the Manager for
+    # any other representations it may know about. We use the form where
+    # we ask for multiple alternate relation types for a single source
+    # reference.
+
+    relationships = [
+        # Ensure we know which entity is the "original"
+        TraitsData({OriginalTrait.kId}),
+        # See if there are any proxies
+        TraitsData({ProxyTrait.kId})
+    ]
+
+    # NB. getRelatedReferences hasn't been moved over to the new
+    # batch/callback syntax yet.
+
+    relations = manager.getRelatedReferences(
+        [entity_reference],
+        relationships,
+        context,
+        # Constrain the results to the same "type" of entity as
+        # the original, eg: image sequences
+        resultTraitSet=entity_trait_set,
+    )
+
+    # The result is a list corresponding to the input relations list
+
+    # OriginalTrait relations - expect there to only be one
+    original_ref = relations[0][0] if relations[0] else None
+    # ProxyTrait relations
+    proxy_refs = relations[1]
+
+    # Early out if we don't have any relations at all
+    if not (original_ref or proxy_refs):
+        return EntityRepresentations(entity_reference, None, [], {})
+
+    # If we do, resolve the references to find out about their entities
+
+    # Resolve all the requested entity traits, and additionally the
+    # proxy trait to see if we have more information about those.
+    # Inapplicable traits are simply ignored by the manager rather than
+    # causing an error.
+    traits_to_resolve = entity_trait_set | {ProxyTrait.kId}
+
+    all_refs = [original_ref] + proxy_refs if original_ref else proxy_refs
+
+    # The batch API uses a callback mechanism. There are plans to add
+    # conveniences for exception based workflows, but these haven't
+    # been written yet...
+
+    # We'll build a map of entity data, keyed by its reference
+    all_data = {}
+
+    def resolve_cb(index: int, entity_data: TraitsData):
+        # https://github.com/OpenAssetIO/OpenAssetIO/issues/802
+        all_data[all_refs[index].toString()] = entity_data
+
+    # We shouldn't really error as we're resolving references the
+    # manager has only just provided us...
+    def error_cb(index: int, error: BatchElementError):
+        raise EntityResolutionError(error.message, all_refs[index])
+
+    manager.resolve(all_refs, traits_to_resolve, context, resolve_cb, error_cb)
+
+    return EntityRepresentations(entity_reference, original_ref, proxy_refs, all_data)
+
+
+def __print_traits_data(data: TraitsData):
+    """
+    Prints out the contents of the supplied TraitsData in a
+    terminal-friendly way.
+    """
+    # We don't have any convenience conversions to dicts etc. yet.
+    # See https://github.com/OpenAssetIO/OpenAssetIO/issues/795
+    as_dict = {
+        trait_id: {
+            property_key: data.getTraitProperty(trait_id, property_key)
+            for property_key in data.traitPropertyKeys(trait_id)
+        }
+        for trait_id in data.traitSet()
+    }
+
+    for trait_id, trait_data in as_dict.items():
+        if trait_data:
+            print(f"  - {trait_id}:")
+            for key, value in trait_data.items():
+                print(f"      {key}: {value}")
+        else:
+            print(f"  - {trait_id}")
+
+
+def main():
+    """
+    Queries the default manager for alternate image sequence
+    representations of the entity reference supplied as the first CLI
+    argument, and prints them to stdout.
+    """
+
+    # Bootstrap the API using the default manager
+
+    logger = SeverityFilter(ConsoleLogger())
+
+    manager = ManagerFactory.defaultManagerForInterface(
+        ProxyWorkflowsHost(), PythonPluginSystemManagerImplementationFactory(logger), logger
+    )
+
+    if not manager:
+        raise RuntimeError(
+            "No default manager configured, "
+            f"check ${ManagerFactory.kDefaultManagerConfigEnvVarName}"
+        )
+
+    # We can now talk to the manager
+
+    # Will throw if input is not an entity reference understood by the manager
+    entity_reference = manager.createEntityReference(sys.argv[1])
+
+    # The context is used to describe who is using the API and tie together
+    # related calls into the API
+    context = manager.createContext()
+    context.locale = ExampleCodeCLISpecification.create().traitsData()
+    context.retention = context.Retention.kTransient
+
+    # See what what image representations we can find for this entity
+    representations = get_all_representations(
+        entity_reference, RasterImageSequenceSpecification.kTraitSet, manager, context
+    )
+
+    # Make a mess of the terminal with the data we got back...
+    # This could easily be used to build OTIO multi-ref timelines, etc...
+    print(f"Representations for: {representations.source.toString()}")
+    if representations.original:
+        print(f"\nOriginal:\n\n{representations.original.toString()}")
+        __print_traits_data(representations.data[representations.original.toString()])
+    if representations.proxies:
+        print("\nProxies:\n")
+        for proxy in representations.proxies:
+            print(f" {proxy.toString()}")
+            __print_traits_data(representations.data[proxy.toString()])
+            print("")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/proxy_workflows/requirements.txt
+++ b/examples/proxy_workflows/requirements.txt
@@ -1,0 +1,1 @@
+openassetio-manager-bal==1.0.0a4

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2021-2022 The Foundry Visionmongers Ltd
+[tool.pylint.messages_control]
+
+[tool.pylint.format]
+max-line-length = 99
+
+[tool.black]
+line-length = 99

--- a/traits.yml
+++ b/traits.yml
@@ -7,6 +7,22 @@ description: Well-known Traits and Specifications for use in OpenAssetIO
 
 traits:
 
+  identity:
+    description: >
+      Traits that identify an entity such as a display name that can be
+      presented to a user.
+    members:
+      DisplayName:
+        description: >
+          A user-facing name for the entity that can be presented to
+          identify the entity to a user.
+        properties:
+          displayName:
+            type: string
+            description: A utf-8 encoded display name.
+        usage:
+          - entity
+
   time:
     description: >
       Traits that describe properties of an entity in terms of its
@@ -278,6 +294,8 @@ specifications:
             name: OCIOColorManaged
           - namespace: content
             name: LocatableContent
+          - namespace: identity
+            name: DisplayName
       RasterImageSequence:
         description: >
           Time-varying pixel based images with data stored in an
@@ -299,6 +317,8 @@ specifications:
             name: OCIOColorManaged
           - namespace: content
             name: LocatableContent
+          - namespace: identity
+            name: DisplayName
           - namespace: time
             name: FrameRanged
   locale:

--- a/traits.yml
+++ b/traits.yml
@@ -6,6 +6,115 @@ description: Well-known Traits and Specifications for use in OpenAssetIO
   hosts and managers.
 
 traits:
+
+  time:
+    description: >
+      Traits that describe properties of an entity in terms of its
+      temporal variation.
+    members:
+      FrameRanged:
+        description: >
+          The temporal dimension of an entity experssed in numbers of
+          whole frames.
+
+
+          NOTE: This is a deliberately naieve definition to serve as
+          a basis for discussion.
+        usage:
+          - entity
+        properties:
+          startFrame:
+            type: integer
+            description: The starting frame.
+          endFrame:
+            type: integer
+            description: The ending frame (inclusive).
+          frameRate:
+            type: float
+            description: The intendent playback rate.
+          stride:
+            type: integer
+            description: >
+              The cadence of images, the deafult is 1, which implies
+              every frame, a value of 10 would indicate only every 10
+              frames are present.
+
+  image:
+    description: >
+      Traits that describe 2D visual content such as pixel and vector
+      based graphics.
+    members:
+      Image:
+        description: A base trait for all 2D visual content.
+        usage:
+          - entity
+      Raster:
+        description: Visual content defined by a 2D grid of pixels.
+        usage:
+          - entity
+        properties:
+          width:
+            type: integer
+            description: The number of columns in the pixel grid.
+          height:
+            type: integer
+            description: The number of rows in the pixel grid.
+          pixelAspectRatio:
+            type: float
+            description: >
+              The aspect ratio of each pixel when presented. Expressed
+              as width/height.
+      OCIOColorManaged:
+        description: >
+          Details of the color space of the image data, when used in an
+          OpenColorIO managed pipeline.
+        usage:
+          - entity
+        properties:
+          colorspace:
+            type: string
+            description: A valid OCIO color space name
+
+  representation:
+    description: >
+      Traits relating to alternate representations of what it otherwise
+      logically the same entity.
+    members:
+      Proxy:
+        description: >
+          An alternate scale/quality representation. In the case of
+          images, this is usually either a lower resolution, reduced
+          quality encoding. For volumetric data this may be reduced
+          spacial fedlity or number of points.
+        usage:
+          - entity
+          - relationship
+        properties:
+          scaleRatio:
+            type: float
+            description: >
+              The ratio of the representations dimension compared to the
+              original.
+          qualityRatio:
+            type: float
+            description: >
+              The ratio of the representations quality compared to the
+              original.
+          label:
+            type: string
+            description: >
+              A short user-facing label that identifies the representation.
+              This should not be the Entity name.
+              
+
+              e.g. "half", "mobile friendly"
+      Original:
+        description: >
+          The original canonical/source representation of the entity
+          from which other proxy representations may have been derived.
+        usage:
+          - relationship
+
   timeline:
     description: Traits related to timelines.
     members:
@@ -136,3 +245,70 @@ traits:
           determine a suitable output location.
         usage:
           - managementPolicy
+
+  locale:
+    description: Traits used to cover commonly occurings locales.
+    members:
+      ExampleCode:
+        description: >
+          A trait that describes API usage within sample code that may
+          be contrived or working with placeholder content in order to
+          demonstrate functionality or workflow approaches.
+      CommandLineInterface:
+        description: >
+          A trait that describes a tool that operates as a CLI or TUI.
+
+
+specifications:
+  image:
+    description: Specifications for commmonly encountered image types.
+    members:
+      RasterImage:
+        description: >
+          Non-animated pixel based images with data stored in an
+          external BLOB.
+        usage:
+          - entity
+        traitSet:
+          - namespace: image
+            name: Image
+          - namespace: image
+            name: Raster
+          - namespace: image
+            name: OCIOColorManaged
+          - namespace: content
+            name: LocatableContent
+      RasterImageSequence:
+        description: >
+          Time-varying pixel based images with data stored in an
+          external BLOB (or BLOBs).
+
+          
+          When the sequence is composed of several individual images,
+          the URL used to locate the content should contain an (URL
+          encoded) sprint-f style token indicating the time-varying part
+          of the sequence's name. Eg file:///data/seq.%2504d.exr.
+        usage:
+          - entity
+        traitSet:
+          - namespace: image
+            name: Image
+          - namespace: image
+            name: Raster
+          - namespace: image
+            name: OCIOColorManaged
+          - namespace: content
+            name: LocatableContent
+          - namespace: time
+            name: FrameRanged
+  locale:
+    description: Specifications for cover commonly occurings locales.
+    members:
+      ExampleCodeCLI:
+        description: A code sample that can be run on the command line.
+        traitSet:
+          - namespace: locale
+            name: ExampleCode
+          - namespace: locale
+            name: CommandLineInterface
+


### PR DESCRIPTION
Adds a sketch workflow example to aid discussion. It demonstrates how OpenAssetIO's `getRelatedReferences` can be used to query alternate representations of an image sequence. Either in the form of the "original" version, or some proxy representation.

 This workflow could be used to rebuild an EDL with alternate versions, for example, a multi-ref OTIO file.

To see [how this works](https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation/blob/772fae7a49890b040cbb8cdbc36589cb1289f636/examples/proxy_workflows/proxies.py) or run the code - see [README.md](https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation/pull/21/files?short_path=3c44483#diff-3c444838644328107a4c1523c329808d2f5cb3eb741608635a08e77e4d2a3c32).

In order to get all this working, it [requires some new traits](https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation/pull/21/files#diff-1ab05cf0d3baf2336b4d422f5442c6e107c88f46245471c69fcf4c59c4d269e1). This PR takes a stab at defining a bunch of common concepts that could be added to the MediaCreation standard library for use across tools in the space. They're just sketches though really, and so are probably not complete or even what might be considered accurate to real-world production use cases. Hopefully they'll serve as an illustration to facilitate a discussion around what they _should_ look like.

> **Note**
> If you want to run the code for yourself, you need to check out the branch on my fork, for this PR, vs `main`. The easiest way to achieve this is with the `gh` [CLI tool](https://cli.github.com):
> ```
> gh repo clone OpenAssetIO/OpenAssetIO-MediaCreation
> cd OpenAssetIO-MediaCreation
> gh pr checkout 21