### PR TITLE
Add `DisplayName` trait in `identity` namespace

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,10 @@ v1.0.0-alpha.x
   generated using `openasset-traitgen`.
   [#24](https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation/issues/24)
 
+- Added the `Displayname` trait which supersedes the `entityName` and
+  `entityDisplayName` methods in the core API.
+  [OpenAssetIO/#837](https://github.com/OpenAssetIO/OpenAssetIO/issues/837)
+
 v1.0.0-alpha.3
 --------------
 

--- a/tests/cpp/test.cpp
+++ b/tests/cpp/test.cpp
@@ -7,6 +7,7 @@
 #include <openassetio_mediacreation/openassetio_mediacreation.hpp>
 #include <openassetio_mediacreation/traits/content.hpp>
 #include <openassetio_mediacreation/traits/content/LocatableContentTrait.hpp>
+#include <openassetio_mediacreation/traits/identity/DisplayNameTrait.hpp>
 #include <openassetio_mediacreation/traits/managementPolicy.hpp>
 #include <openassetio_mediacreation/traits/managementPolicy/ManagedTrait.hpp>
 #include <openassetio_mediacreation/traits/managementPolicy/ResolvesFutureEntitiesTrait.hpp>

--- a/tests/python/openassetio_mediacreation/test_imports.py
+++ b/tests/python/openassetio_mediacreation/test_imports.py
@@ -52,3 +52,6 @@ class Test_trait_imports:
 
     def test_importing_ResolvesFutureEntitiesTrait_succeeds(self):
         from openassetio_mediacreation.traits.managementPolicy import ResolvesFutureEntitiesTrait
+
+    def test_importing_DisplayNameTrait_succeeds(self):
+        from openassetio_mediacreation.traits.identity import DisplayNameTrait

--- a/traits.yml
+++ b/traits.yml
@@ -73,6 +73,43 @@ traits:
 
               This must be a valid URL so special characters need to
               be encoded.
+  identity:
+    description: Traits that aid identification of an entity
+    members:
+      DisplayName:
+        description: >
+          Names that can be presented to a user in order to identify
+          and/or disambiguate the entity. These strings are potentially
+          unstable and should not be used as a UUID or other persistent
+          anchor.
+        usage:
+          - entity
+        properties:
+          name:
+            type: string
+            description: |
+              The humanized name of entity itself, not including any
+              hierarchy or classification.
+
+              For example:
+              - `"Cuttlefish v1"` - for a version of an asset
+              - `"seq003"` - for a sequence in a hierarchy
+
+          qualifiedName:
+            type: string
+            description: |
+              An unambiguous, humanised name for the entity.
+
+              The display name may want to consider the host, and any other
+              relevant Context information to form a display name for an
+              entity that can uniquely identify the entity in that context.
+
+              For example:
+              - `"dive / build / cuttlefish / model / v1"` for a version
+                  of an asset in an 'open recent' menu.
+              - `"Sequence 003 [ Dive / Episode 1 ]"` for a sequence in
+                 an hierarchy as a window title.
+
 
   managementPolicy:
     description: Traits used in a Manager's managementPolicy response.


### PR DESCRIPTION
OpenAssetIO used to have `entityName` and `entityDisplayName` methods. It makes more sense to use a trait for entity identity as the specifics of this may well be industry specific, and it potentially avoids several additional API calls in common scenarios.

The definitions are largely lifed from the old API methods, with minor massaging of property names to attempt to be more coherent.

Part of https://github.com/OpenAssetIO/OpenAssetIO/issues/837