### PR TITLE
[Traits] Add placeholder auth.BearerToken trait for SIGGRAPH demo

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,10 @@ v1.0.0-alpha.x
 
 - Removed speculative timeline traits pending real-world use cases.
 
+### New Features
+
+- Added `openassetio_mediacreation.traits.auth.BearerTokenTrait`.
+
 v1.0.0-alpha.5
 --------------
 

--- a/tests/python/openassetio_mediacreation/test_imports.py
+++ b/tests/python/openassetio_mediacreation/test_imports.py
@@ -43,3 +43,6 @@ class Test_trait_imports:
 
     def test_importing_DisplayNameTrait_succeeds(self):
         from openassetio_mediacreation.traits.identity import DisplayNameTrait
+
+    def test_importing_BearerToken_succeeds(self):
+        from openassetio_mediacreation.traits.auth import BearerTokenTrait

--- a/traits.yml
+++ b/traits.yml
@@ -131,3 +131,18 @@ traits:
           determine a suitable output location.
         usage:
           - managementPolicy
+
+  auth:
+    description: Traits related to authentication and authorization.
+    members:
+      BearerToken:
+        description: >
+          This trait holds an authentication token that the manager may
+          pass to a back-end service.
+        usage:
+          - locale
+        properties:
+          token:
+            type: string
+            description: >
+              Contents of the token.


### PR DESCRIPTION
Discussed with @foundrytom on Friday, I'd like to add this trait for the SIGGRAPH review workflow demo. I'll ask the MovieLabs manager to enable EasyCLA on this repo...