### PR TITLE
[Traits] Remove speculative timeline traits

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+
+### Breaking changes
+
+- Removed speculative timeline traits pending real-world use cases.
+
 v1.0.0-alpha.5
 --------------
 

--- a/tests/cpp/test.cpp
+++ b/tests/cpp/test.cpp
@@ -11,10 +11,6 @@
 #include <openassetio_mediacreation/traits/managementPolicy.hpp>
 #include <openassetio_mediacreation/traits/managementPolicy/ManagedTrait.hpp>
 #include <openassetio_mediacreation/traits/managementPolicy/ResolvesFutureEntitiesTrait.hpp>
-#include <openassetio_mediacreation/traits/timeline.hpp>
-#include <openassetio_mediacreation/traits/timeline/ClipTrait.hpp>
-#include <openassetio_mediacreation/traits/timeline/TimelineTrait.hpp>
-#include <openassetio_mediacreation/traits/timeline/TrackTrait.hpp>
 #include <openassetio_mediacreation/traits/traits.hpp>
 
 using namespace openassetio_mediacreation;

--- a/tests/python/openassetio_mediacreation/test_imports.py
+++ b/tests/python/openassetio_mediacreation/test_imports.py
@@ -29,20 +29,8 @@ class Test_trait_imports:
     def test_importing_traits_succeeds(self):
         from openassetio_mediacreation import traits
 
-    def test_importing_timeline_succeeds(self):
-        from openassetio_mediacreation.traits import timeline
-
     def test_importing_content_succeeds(self):
         from openassetio_mediacreation.traits import content
-
-    def test_importing_ClipTrait_succeeds(self):
-        from openassetio_mediacreation.traits.timeline import ClipTrait
-
-    def test_importing_TimelineTrait_succeeds(self):
-        from openassetio_mediacreation.traits.timeline import TimelineTrait
-
-    def test_importing_TrackTrait_succeeds(self):
-        from openassetio_mediacreation.traits.timeline import TrackTrait
 
     def test_importing_LocatableContentTrait_succeeds(self):
         from openassetio_mediacreation.traits.content import LocatableContentTrait

--- a/traits.yml
+++ b/traits.yml
@@ -6,48 +6,6 @@ description: Well-known Traits and Specifications for use in OpenAssetIO
   hosts and managers.
 
 traits:
-  timeline:
-    description: Traits related to timelines.
-    members:
-      Timeline:
-        description: >
-          This trait characterizes a collection of tracks that evaluate
-          concurrently to form layers of references to media. Frequently
-          used in non-linear editing environments such as Video and
-          Audio post production tools.
-        usage:
-          - entity
-          - locale
-
-      Track:
-        description: >
-          This trait characterizes a lane or collection of media,
-          arranged temporally such that only a single item in the
-          collection is active at any given time. Frequently used in
-          non-linear editing environments such as Video and Audio post
-          production tools.
-        usage:
-          - entity
-          - locale
-
-      Clip:
-        description: >
-          This trait characterizes the use of some range of external
-          media, commonly on a track or timeline. Frequently used in
-          non-linear editing environments such as Video and Audio
-          production tools.
-
-
-          TODO(TC) Define any additional properties, and companion
-          traits such as 'frameRange' and 'handles'.
-        usage:
-          - entity
-          - locale
-        properties:
-          name:
-            type: string
-            description: The name of the clip.
-
   content:
     description: Traits related to abstract content.
     members:


### PR DESCRIPTION
These had originally been added for the `otio-openassetio` prototype. This has since stopped using them on the basis that highly specific locales tend to preclude batching. Until all this settles down, and we have a significant number of real integrations producing scenarios where we do need more information, we should aim to keep the locale as minimal as possible to maximize batching opportunities.