### PR TITLE
Simplify C++ header imports in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,9 @@ ctest --test-dir build/tests/cpp
 This repository follows the [contribution guidelines](https://github.com/TheFoundryVisionmongers/OpenAssetIO/blob/main/contributing/PROCESS.md)
 outlined in the main OpenAssetIO repository. All discussion most
 welcome!
+
+When adding new Traits and Specifications:
+
+1. Update [traits.yml](traits.yml)
+2. Add an [import test](tests/python/openassetio_mediacreation/test_imports.py)
+3. Update the [RELEASE_NOTES](RELEASE_NOTES.md)

--- a/tests/cpp/test.cpp
+++ b/tests/cpp/test.cpp
@@ -1,17 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 The Foundry Visionmongers Ltd
 
-// Include all headers to test they are where we expect and can be
-// compiled.
+// Include all headers to test they can be compiled.
 
 #include <openassetio_mediacreation/openassetio_mediacreation.hpp>
-#include <openassetio_mediacreation/traits/content.hpp>
-#include <openassetio_mediacreation/traits/content/LocatableContentTrait.hpp>
-#include <openassetio_mediacreation/traits/identity/DisplayNameTrait.hpp>
-#include <openassetio_mediacreation/traits/managementPolicy.hpp>
-#include <openassetio_mediacreation/traits/managementPolicy/ManagedTrait.hpp>
-#include <openassetio_mediacreation/traits/managementPolicy/ResolvesFutureEntitiesTrait.hpp>
-#include <openassetio_mediacreation/traits/traits.hpp>
 
 using namespace openassetio_mediacreation;
 


### PR DESCRIPTION
We previously explicitly imported all the C++ headers. This served to verify that the YAML produced the correct outputs. We also do this in Python though, so this is really mostly testing TraitGen.

We have a rule of thumb that we don't re-test auto-generated code, and the C++ tooling requirements have been noted to form a barrier to entry to contributors who may work mostly in the Python world.

As, assuming we trust TraitGen, all generated headers are still imported by the package header, this commit removes the explicit imports of individual trait headers. This means we should still test that all shipping headers are syntax correct.