### PR TITLE
[Build] Add hybrid python generation to cmake.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         run: python -m pytest -v
 
   test-cpp:
-    name: Test-Cpp
+    name: Test Cpp
     runs-on: ubuntu-latest
     needs: build-openassetio
     container:
@@ -68,3 +68,34 @@ jobs:
 
       - name: Test
         run: ctest -VV --test-dir build/tests/cpp --parallel 2
+
+  test-python-from-cmake:
+  # To support hybrid C++ applications, the python package may also be
+  # generated using the CMake packaging, in addition and simultaneously
+  # to the C++ package. This tests that.
+    name: "Test Python From CMake"
+    runs-on: ubuntu-latest
+    container:
+      image: aswf/ci-vfxall:2022-clang14.3
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Traitgen
+        run: python -m pip install openassetio-traitgen==1.0.0a6
+
+      - name: Configure CMake build
+        run: >
+          cmake -S . -B build -G Ninja
+          -DOPENASSETIO_MEDIACREATION_GENERATE_PYTHON=ON
+          -DOPENASSETIO_MEDIACREATION_PYTHON_SITEDIR="hybridpython"
+
+      - name: Install package
+        run: cmake --install build
+
+      - name: Install OpenAssetIO
+        run: python -m pip install openassetio>=1.0.0a6
+
+      - name: Test
+        run: |
+          python -m pip install -r tests/python/requirements.txt
+          PYTHONPATH=$(pwd)/build/dist/hybridpython python -m pytest -v

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,18 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 #-----------------------------------------------------------------------
 # Options
 option(OPENASSETIO_MEDIACREATION_ENABLE_TEST "Run test on mediacreation traits" OFF)
+option(OPENASSETIO_MEDIACREATION_GENERATE_PYTHON "Aditionally generate python library" OFF)
+if (OPENASSETIO_MEDIACREATION_GENERATE_PYTHON)
+    # By default we'll compute the correct site-packages directory
+    # structure, but allow overriding.
+    set(OPENASSETIO_MEDIACREATION_PYTHON_SITEDIR
+        ""
+        CACHE STRING
+        "Override default Python module install directory, relative to CMAKE_INSTALL_PREFIX")
+endif ()
+
 message(STATUS "Test enabled = ${OPENASSETIO_MEDIACREATION_ENABLE_TEST}")
+message(STATUS "Generate python library = ${OPENASSETIO_MEDIACREATION_GENERATE_PYTHON}")
 
 # ABI wrangling only needed for test
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
@@ -61,9 +72,28 @@ message("Generating Traits with openassetio-traitgen")
 # This means if the source traits file is changed, configure will rerun.
 configure_file(${CMAKE_CURRENT_LIST_DIR}/traits.yml ${PROJECT_BINARY_DIR}/traits.yml)
 execute_process(COMMAND openassetio-traitgen ${PROJECT_BINARY_DIR}/traits.yml
-                -o ${PROJECT_BINARY_DIR} -g cpp
-                COMMAND_ERROR_IS_FATAL ANY
-                COMMAND_ECHO STDERR)
+                    -o ${PROJECT_BINARY_DIR}/cpp -g cpp
+                    COMMAND_ERROR_IS_FATAL ANY
+                    COMMAND_ECHO STDERR)
+
+if (OPENASSETIO_MEDIACREATION_GENERATE_PYTHON)
+    # Generate the python package by running traitgen.
+    # By running traitgen during the cmake step, using the traitgen that
+    # is available to the environment, just as the C++ generation does,
+    # we guarentee that the versions of traitgen used between c++ and
+    # python packages are identical. This isn't a guarentee when using
+    # the `pip install .` method of creating a python package, due to
+    # pip having a seperate dependency resolution method.
+    #
+    # At the time of writing, this produces the same artifact as doing
+    # `pip install .` (and invoking setup.py), but that's not a
+    # guarentee going forward, as additional elements of the python
+    # package may be added to mediacreation.
+    execute_process(COMMAND openassetio-traitgen ${PROJECT_BINARY_DIR}/traits.yml
+        -o ${PROJECT_BINARY_DIR}/python -g python
+        COMMAND_ERROR_IS_FATAL ANY
+        COMMAND_ECHO STDERR)
+endif()
 
 add_library(openassetio-mediacreation INTERFACE)
 # add alias so the project can be used with add_subdirectory
@@ -71,11 +101,11 @@ add_library(OpenAssetIO-MediaCreation::openassetio-mediacreation ALIAS openasset
 
 include(GNUInstallDirs)
 
-# traitgen generates to _public_header_source_root location by default.
-set(_public_header_source_root "${PROJECT_BINARY_DIR}/openassetio_mediacreation/include")
+# traitgen generates to _public_header_source_root/cpp location by default.
+set(_public_header_source_root "${PROJECT_BINARY_DIR}/cpp/openassetio_mediacreation/include")
 set(_config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-set(_project_config_file "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
-set(_version_config_file "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+set(_project_config_file "${PROJECT_BINARY_DIR}/cpp/${PROJECT_NAME}Config.cmake")
+set(_version_config_file "${PROJECT_BINARY_DIR}/cpp/${PROJECT_NAME}ConfigVersion.cmake")
 set(_traitgen_data_dir "${CMAKE_INSTALL_DATADIR}/openassetio-traitgen")
 
 #-----------------------------------------------------------------------
@@ -111,6 +141,18 @@ install(
     NAMESPACE ${PROJECT_NAME}::
     FILE ${PROJECT_NAME}Targets.cmake
 )
+
+#-----------------------------------------------------------------------
+# Optionally install python library
+if (OPENASSETIO_MEDIACREATION_GENERATE_PYTHON)
+    include(ThirdParty)
+
+    install(
+        DIRECTORY ${PROJECT_BINARY_DIR}/python/openassetio_mediacreation
+        DESTINATION "${OPENASSETIO_MEDIACREATION_PYTHON_SITEDIR}"
+        FILES_MATCHING PATTERN "*.py"
+    )
+endif()
 
 #-----------------------------------------------------------------------
 # Copy CMake Files

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+### New Features
+
+- Added ability to generate python package whilst installing via cmake
+  build system.
+  Added cmake variables `OPENASSETIO_MEDIACREATION_GENERATE_PYTHON` and
+  `OPENASSETIO_MEDIACREATION_PYTHON_SITEDIR` to support this.
+
 v1.0.0-alpha.6
 --------------
 

--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -1,0 +1,44 @@
+#-----------------------------------------------------------------------
+# Python
+
+if (OPENASSETIO_MEDIACREATION_GENERATE_PYTHON)
+    #-------------------------------------------------------------------
+    # Locate packages
+
+    # Locate the Python package.
+    find_package(Python REQUIRED COMPONENTS Interpreter)
+
+    # Debug log some outputs expected from the built-in FindPython.
+    message(TRACE "Python_EXECUTABLE = ${Python_EXECUTABLE}")
+    message(TRACE "Python_INTERPRETER_ID = ${Python_INTERPRETER_ID}")
+    message(TRACE "Python_STDLIB = ${Python_STDLIB}")
+    message(TRACE "Python_STDARCH = ${Python_STDARCH}")
+    message(TRACE "Python_SITELIB = ${Python_SITELIB}")
+    message(TRACE "Python_SITEARCH = ${Python_SITEARCH}")
+    message(TRACE "Python_SOABI = ${Python_SOABI}")
+    message(TRACE "Python_INCLUDE_DIRS = ${Python_INCLUDE_DIRS}")
+    message(TRACE "Python_LINK_OPTIONS = ${Python_LINK_OPTIONS}")
+    message(TRACE "Python_LIBRARIES = ${Python_LIBRARIES}")
+    message(TRACE "Python_LIBRARY_DIRS = ${Python_LIBRARY_DIRS}")
+    message(TRACE "Python_RUNTIME_LIBRARY_DIRS = ${Python_RUNTIME_LIBRARY_DIRS}")
+    message(TRACE "Python_VERSION = ${Python_VERSION}")
+    message(TRACE "Python_VERSION_MAJOR = ${Python_VERSION_MAJOR}")
+    message(TRACE "Python_VERSION_MINOR = ${Python_VERSION_MINOR}")
+    message(TRACE "Python_VERSION_PATCH = ${Python_VERSION_PATCH}")
+
+    if (OPENASSETIO_MEDIACREATION_PYTHON_SITEDIR STREQUAL "")
+        # Make a naive assumption about a suitable structure under our
+        # install-dir. See:
+        #   https://discuss.python.org/t/understanding-site-packages-directories/12959
+        # We had issues using 'cleverness' to work out the path relative
+        # to Python_EXECUTABLE and Python_SITEARCH when symlinks or
+        # varying installation structures were used (eg GitHub Actions
+        # runners).
+        if (WIN32)
+            set(OPENASSETIO_MEDIACREATION_PYTHON_SITEDIR "Lib/site-packages")
+        else ()
+            set(OPENASSETIO_MEDIACREATION_PYTHON_SITEDIR
+                "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+        endif ()
+    endif ()
+endif()


### PR DESCRIPTION
Closes #49 
Adds the ability to optionally and additionally generate the python package when running under the cmake build system.

This is intended to enable hybrid hosts/managers to get both of their required libraries out without needing to call out/synchronize between multiple build systems (cmake & pip)

Adds `OPENASSETIO_MEDIACREATION_GENERATE_PYTHON` as the toggle variable, and `OPENASSETIO_MEDIACREATION_PYTHON_SITEDIR` as the location override variable.

Brings in the python part of `ThirdParty.cmake` from the OpenAssetIO directory to do the path intuition for the sitedir.

Added a test that invokes the cmake generation and runs the import test suite by setting the pythonpath.