### PR TITLE
[Traits] Remove `ResolvesFutureEntities` trait

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,14 @@ Release Notes
 v1.0.0-alpha.x
 --------------
 
+### Breaking changes
+
+- Removed the `ResolvesFutureEntities` trait in favour of the [core API
+  mechanism](https://github.com/OpenAssetIO/OpenAssetIO/issues/1209) for
+  determining which traits can be resolved for future entities by any
+  given manager.
+  [#67](https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation/issues/67)
+
 ### Improvements
 
 - Pinned `openassetio-traitgen` to `v1.0.0a7` to ensure backwards

--- a/tests/python/openassetio_mediacreation/test_imports.py
+++ b/tests/python/openassetio_mediacreation/test_imports.py
@@ -38,9 +38,6 @@ class Test_trait_imports:
     def test_importing_ManagedTrait_succeeds(self):
         from openassetio_mediacreation.traits.managementPolicy import ManagedTrait
 
-    def test_importing_ResolvesFutureEntitiesTrait_succeeds(self):
-        from openassetio_mediacreation.traits.managementPolicy import ResolvesFutureEntitiesTrait
-
     def test_importing_DisplayNameTrait_succeeds(self):
         from openassetio_mediacreation.traits.identity import DisplayNameTrait
 

--- a/traits.yml
+++ b/traits.yml
@@ -218,27 +218,6 @@ traits:
 
               If False, then standard host controls can be presented in
               addition to any custom manager UI.
-      ResolvesFutureEntities:
-        description: >
-          A trait indicating a manager can potentially resolve the
-          supplied trait set for future entities.
-
-
-          If not imbued, the manager is not capable of determining data
-          in advance for new entities, and is only capable of resolving
-          traits for exising ones.
-
-
-          An example of this would be the ability to resolve a
-          LocatableContentTrait in advance, to determine where new data
-          should be written. When this trait imbued in the
-          managementPolicy response, a host may attempt to resolve the
-          locatableContent trait of a working entity reference supplied by
-          preflight in order to determine a suitable output path before
-          work is done. In its absence, a host must use alternate means to
-          determine a suitable output location.
-        usage:
-          - managementPolicy
   relationship:
     description: Traits specific to qualities of a relationship.
     members:


### PR DESCRIPTION
The core API will be providing a proper mechanism to introspect this aspect of a managers operation:

 https://github.com/OpenAssetIO/OpenAssetIO/issues/1209

 Closes #67

This poses the question about what do we want to do in the examples:
- Leave it, itll be reet.
- Update to `kDerived` (or whatever)