### PR TITLE
[Docs] Add FilePathUrlConverter notebook

### DIFF
--- a/examples/file_path_url_converter.ipynb
+++ b/examples/file_path_url_converter.ipynb
@@ -1,0 +1,460 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3c31ad961569bbe8",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "# File path <-> URL conversion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2c2a12c608d5531",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Given the (current) lack of cross-platform lightweight C/C++ libraries for converting paths to/from `file://` URLs, OpenAssetIO comes bundled with a built-in utility to accomplish this.\n",
+    "\n",
+    "This is in the form of a class `FilePathUrlConverter` with two methods `pathToUrl` and `pathFromUrl`.\n",
+    "\n",
+    "The implementation conforms to the large test case database used in the [swift-url](https://github.com/karwa/swift-url) project.\n",
+    "\n",
+    "The `FilePathUrlConverter` class is not cheap to instantiate (it precompiles several regular expressions on construction). High-performance scenarios should construct a single instance and re-use it for each conversion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c068bd7413724211",
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-19T15:10:35.668132096Z",
+     "start_time": "2024-02-19T15:10:35.661355780Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from openassetio.utils import FileUrlPathConverter\n",
+    "\n",
+    "\n",
+    "converter = FileUrlPathConverter()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1141a17cb56e1a83",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "## The basics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "766ebf4c22bddee4",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "The converter functions take a `PathType` parameter, to specify the intended platform, either `kWindows`, `kPOSIX` or `kSystem`.\n",
+    "\n",
+    "Lets try a canonical Windows path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1ecc6576865b32c",
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-19T15:10:35.750564608Z",
+     "start_time": "2024-02-19T15:10:35.669692678Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": "> **Result:**\n> - `URL: file:///C:/path/to/file.ext`\n> - `Path: C:\\path\\to\\file.ext`"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from resources.helpers import display_result\n",
+    "from openassetio.utils import PathType\n",
+    "\n",
+    "\n",
+    "url = converter.pathToUrl(r\"C:\\path\\to\\file.ext\", PathType.kWindows)\n",
+    "path = converter.pathFromUrl(url, PathType.kWindows)\n",
+    "\n",
+    "display_result((f\"URL: {url}\", f\"Path: {path}\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97468411bbab92d6",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "And similarly for POSIX"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "eb8028d72eca68d7",
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-19T15:10:35.751558242Z",
+     "start_time": "2024-02-19T15:10:35.746229492Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": "> **Result:**\n> - `URL: file:///path/to/file.ext`\n> - `Path: /path/to/file.ext`"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "url = converter.pathToUrl(r\"/path/to/file.ext\", PathType.kPOSIX)\n",
+    "path = converter.pathFromUrl(url, PathType.kPOSIX)\n",
+    "\n",
+    "display_result((f\"URL: {url}\", f\"Path: {path}\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10be755193d9f86",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "If we pass `PathType.kSystem`, or leave that argument empty, then the path will be converted assuming the current platform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ce23f609c7f21e88",
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-19T15:10:35.752221829Z",
+     "start_time": "2024-02-19T15:10:35.746760363Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": "> **Result:**\n> - `System URL: file:////path/to/file.ext`\n> - `POSIX URL: file:////path/to/file.ext`\n> - `Windows URL: file://path/to/file.ext`\n> - `Path from system URL: //path/to/file.ext`\n> - `Path from POSIX URL: //path/to/file.ext`\n> - `Path from Windows URL: \\\\path\\to\\file.ext`"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Convert path to URL.\n",
+    "\n",
+    "url_default = converter.pathToUrl(r\"//path/to/file.ext\")\n",
+    "url_system = converter.pathToUrl(r\"//path/to/file.ext\", PathType.kSystem)\n",
+    "assert url_default == url_system\n",
+    "\n",
+    "url_windows = converter.pathToUrl(r\"//path/to/file.ext\", PathType.kWindows)\n",
+    "url_posix = converter.pathToUrl(r\"//path/to/file.ext\", PathType.kPOSIX)\n",
+    "\n",
+    "# Convert URL back to path.\n",
+    "\n",
+    "path_default = converter.pathFromUrl(url_default)\n",
+    "path_system = converter.pathFromUrl(url_system, PathType.kSystem)\n",
+    "assert path_default == path_system\n",
+    "\n",
+    "path_windows = converter.pathFromUrl(url_windows, PathType.kWindows)\n",
+    "path_posix = converter.pathFromUrl(url_posix, PathType.kPOSIX)\n",
+    "\n",
+    "display_result(\n",
+    "    (f\"System URL: {url_system}\", f\"POSIX URL: {url_posix}\", f\"Windows URL: {url_windows}\",\n",
+    "     f\"Path from system URL: {path_system}\", f\"Path from POSIX URL: {path_posix}\", f\"Path from Windows URL: {path_windows}\"\n",
+    "     ))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "847f7162603dea0d",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Note that on POSIX, `//path/to` is valid (the leading double-`/` is implementation-dependent), and on Windows, `//path/to` refers to a UNC share path with host `path` and share name `to`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1e239a5c0800da7",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "## Platform-specific validation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7db487e7c4755276",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "The given path must be absolute. The structure of an absolute path is platform-specific. If we try the Windows path with a POSIX path type, we'll get an error because there is no leading `/`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1b15171b88c9815a",
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-19T15:10:35.752788470Z",
+     "start_time": "2024-02-19T15:10:35.747166792Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": "> **Result:**\n> `Path is relative ('C:\\path\\to\\file.ext')`"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from openassetio.errors import InputValidationException\n",
+    "\n",
+    "\n",
+    "try:\n",
+    "    url = converter.pathToUrl(r\"C:\\path\\to\\file.ext\", PathType.kPOSIX)\n",
+    "except InputValidationException as exc:\n",
+    "    display_result(exc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c02f6df02faaa05",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Similarly, if we try the POSIX path with a Windows path type, the same error is raised, because there is no leading drive letter or UNC host."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "9ecf85f0957b324c",
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-19T15:10:35.753369976Z",
+     "start_time": "2024-02-19T15:10:35.747539701Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": "> **Result:**\n> `Path is relative ('/path/to/file.ext')`"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    url = converter.pathToUrl(r\"/path/to/file.ext\", PathType.kWindows)\n",
+    "except InputValidationException as exc:\n",
+    "    display_result(exc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "474e0872ce4ca587",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "There are many other examples where validation and conversion are platform-dependent beyond this."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bbd08b385f0b211f",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "## Windows specifics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "243f917365cb5fc5",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Windows has several types of path, drive paths, UNC paths and UNC device paths, with and without normalisation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1b6d34e0ef217b2d",
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-19T15:10:35.754178890Z",
+     "start_time": "2024-02-19T15:10:35.748805566Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": "> **Result:**\n> - `Drive URL: file:///C:/path/to/file.ext`\n> - `UNC share URL: file://host/share/path/to/file.ext`\n> - `UNC device drive URL: file:///C:/path/to/file.ext`\n> - `UNC device share URL: file://host/share/path/to/file.ext`\n> - `Path from drive URL: C:\\path\\to\\file.ext`\n> - `Path from UNC share URL: \\\\host\\share\\path\\to\\file.ext`\n> - `Path from UNC device drive URL: C:\\path\\to\\file.ext`\n> - `Path from UNC device share URL: \\\\host\\share\\path\\to\\file.ext`"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# (Normalised) drive path\n",
+    "url_drive = converter.pathToUrl(r\"C:/path\\to\\/\\file.ext\", PathType.kWindows)\n",
+    "path_drive = converter.pathFromUrl(url_drive, PathType.kWindows)\n",
+    "\n",
+    "# (Normalised) UNC share path\n",
+    "url_unc_share = converter.pathToUrl(r\"\\\\host/share\\path\\to\\/\\file.ext\", PathType.kWindows)\n",
+    "path_unc_share = converter.pathFromUrl(url_unc_share, PathType.kWindows)\n",
+    "\n",
+    "# Non-normalised UNC device drive path\n",
+    "url_device_drive = converter.pathToUrl(r\"\\\\?\\C:\\path\\to\\file.ext\", PathType.kWindows)\n",
+    "path_device_drive = converter.pathFromUrl(url_device_drive, PathType.kWindows)\n",
+    "\n",
+    "# Non-normalised UNC device share path\n",
+    "url_device_share = converter.pathToUrl(r\"\\\\?\\UNC\\host\\share\\path\\to\\file.ext\", PathType.kWindows)\n",
+    "path_device_share = converter.pathFromUrl(url_device_share, PathType.kWindows)\n",
+    "\n",
+    "display_result(\n",
+    "    (f\"Drive URL: {url_drive}\", f\"UNC share URL: {url_unc_share}\",\n",
+    "     f\"UNC device drive URL: {url_device_drive}\",\n",
+    "     f\"UNC device share URL: {url_device_share}\",\n",
+    "     f\"Path from drive URL: {path_drive}\", f\"Path from UNC share URL: {path_unc_share}\",\n",
+    "     f\"Path from UNC device drive URL: {path_device_drive}\",\n",
+    "     f\"Path from UNC device share URL: {path_device_share}\"\n",
+    "     ))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4b21091a21ff7ca",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Note that information is lost when converting to a `file` URL, i.e.whether the path was originally a device path or not. This can have implications for device paths that cannot be normalised, e.g. going beyond the `MAX_PATH` limit. Addressing this is the subject of future work."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb41ffc96d1228d9",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "### Unsupported Windows path features"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a1a9ca3c25b918d",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "Normalised UNC device paths of the form `\\\\.\\` are not yet supported. \n",
+    "\n",
+    "Usage of `/` in device paths are also not (yet) supported. Non-normalised device paths should treat these as file name components, not path separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "23bd55feb9d6f65b",
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-19T15:10:35.755287822Z",
+     "start_time": "2024-02-19T15:10:35.749198579Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": "> **Result:**\n> `Path references an invalid hostname ('\\\\.\\C:\\path\\to\\file.ext')`"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": "> **Result:**\n> `Unsupported Win32 device path ('\\\\?\\C:\\path/to\\file.ext')`"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    url = converter.pathToUrl(r\"\\\\.\\C:\\path\\to\\file.ext\", PathType.kWindows)\n",
+    "except InputValidationException as exc:\n",
+    "    display_result(exc)\n",
+    "\n",
+    "try:\n",
+    "    url = converter.pathToUrl(r\"\\\\?\\C:\\path/to\\file.ext\", PathType.kWindows)\n",
+    "except InputValidationException as exc:\n",
+    "    display_result(exc)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Following on from OpenAssetIO/OpenAssetIO#1117 add a Jupyter Notebook illustrating the usage of `FilePathUrlConverter`.

This is in no way complete, and was used as part of a live demo in sprint review. It seems like useful documentation nonetheless and worth keeping in the repo.