### PR TITLE
[Release] Bump version to v1.0.0-alpha.8

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-v1.0.0-beta.x
+v1.0.0-alpha.8
 ---------------
 
 ### New features

--- a/examples/resources/requirements.txt
+++ b/examples/resources/requirements.txt
@@ -1,5 +1,5 @@
 jupyter
 openassetio>=v1.0.0b1rev0
-openassetio-manager-bal>=v1.0.0a13
+openassetio-manager-bal>=v1.0.0a14
 openassetio-mediacreation
 Pillow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openassetio-mediacreation"
-version = "1.0.0a7"
+version = "1.0.0a8"
 requires-python = ">=3.7"
-dependencies = ["openassetio>=1.0.0a6"]
+dependencies = ["openassetio>=1.0.0b2"]
 
 authors = [
     { name = "Contributors to the OpenAssetIO project", email = "openassetio-discussion@lists.aswf.io" }
@@ -45,8 +45,6 @@ OpenAssetIO hosts and managers. For more information on this mechanism,
 see the [OpenAssetIO docs](https://openassetio.github.io/OpenAssetIO/).
 """
 content-type = "text/markdown"
-
-dependencies = ["openassetio>=1.0.0a6"]
 
 [tool.setuptools]
 packages = ["openassetio_mediacreation"]


### PR DESCRIPTION
Bump OpenAssetIO dependency now that `ResolvesFutureEntities` has been removed in favour of a `managementPolicy` query in the core API.

Bump BAL dependency to minimum compatible with latest OpenAssetIO version 1.0.0-beta.2.0 (newly required method, `entityTraits`).