### PR TITLE
[CI] Use x86 MacOS for tests

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-latest", "ubuntu-latest", "macos-latest"]
+        os: ["windows-latest", "ubuntu-latest", "macos-13"]
         python: ["3.7", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-latest", "ubuntu-latest", "macos-latest"]
+        os: ["windows-latest", "ubuntu-latest", "macos-13"]
         python: ["3.7", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3

--- a/examples/management_policies.ipynb
+++ b/examples/management_policies.ipynb
@@ -36,12 +36,12 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-01-30T18:11:38.083252222Z",
-     "start_time": "2024-01-30T18:11:38.027702394Z"
+     "end_time": "2024-03-13T07:56:17.566800Z",
+     "start_time": "2024-03-13T07:56:17.527306Z"
     }
    },
    "id": "320f8ec6b0f6ea91",
-   "execution_count": 28
+   "execution_count": 1
   },
   {
    "cell_type": "markdown",
@@ -96,7 +96,7 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "> **Result:**\n> `{'openassetio-mediacreation:threeDimensional.Spatial', 'openassetio-mediacreation:content.LocatableContent', 'openassetio-mediacreation:usage.Entity', 'openassetio-mediacreation:threeDimensional.Geometry'}`"
+      "text/markdown": "> **Result:**\n> `{'openassetio-mediacreation:threeDimensional.Geometry', 'openassetio-mediacreation:threeDimensional.Spatial', 'openassetio-mediacreation:usage.Entity', 'openassetio-mediacreation:content.LocatableContent'}`"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -112,12 +112,12 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-01-30T18:11:38.085519931Z",
-     "start_time": "2024-01-30T18:11:38.083540633Z"
+     "end_time": "2024-03-13T07:56:17.571179Z",
+     "start_time": "2024-03-13T07:56:17.567945Z"
     }
    },
    "id": "2bae30e4867eeda5",
-   "execution_count": 29
+   "execution_count": 2
   },
   {
    "cell_type": "markdown",
@@ -138,7 +138,7 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "> **Result:**\n> `{'openassetio-mediacreation:managementPolicy.Managed', 'openassetio-mediacreation:content.LocatableContent'}`"
+      "text/markdown": "> **Result:**\n> `{'openassetio-mediacreation:content.LocatableContent', 'openassetio-mediacreation:managementPolicy.Managed'}`"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -156,12 +156,12 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-01-30T18:11:38.094002337Z",
-     "start_time": "2024-01-30T18:11:38.087824298Z"
+     "end_time": "2024-03-13T07:56:17.577252Z",
+     "start_time": "2024-03-13T07:56:17.572127Z"
     }
    },
    "id": "ab5b8d3b8748b804",
-   "execution_count": 30
+   "execution_count": 3
   },
   {
    "cell_type": "markdown",
@@ -201,12 +201,12 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-01-30T18:11:38.143527731Z",
-     "start_time": "2024-01-30T18:11:38.091712050Z"
+     "end_time": "2024-03-13T07:56:17.582858Z",
+     "start_time": "2024-03-13T07:56:17.578628Z"
     }
    },
    "id": "4c355b5a8961023a",
-   "execution_count": 31
+   "execution_count": 4
   },
   {
    "cell_type": "markdown",
@@ -243,7 +243,7 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "> **Result:**\n> `{'openassetio-mediacreation:color.OCIOColorManaged', 'openassetio-mediacreation:twoDimensional.Image', 'openassetio-mediacreation:content.LocatableContent', 'openassetio-mediacreation:twoDimensional.PixelBased', 'openassetio-mediacreation:twoDimensional.Planar', 'openassetio-mediacreation:usage.Entity'}`"
+      "text/markdown": "> **Result:**\n> `{'openassetio-mediacreation:color.OCIOColorManaged', 'openassetio-mediacreation:twoDimensional.PixelBased', 'openassetio-mediacreation:content.LocatableContent', 'openassetio-mediacreation:twoDimensional.Planar', 'openassetio-mediacreation:twoDimensional.Image', 'openassetio-mediacreation:usage.Entity'}`"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -262,12 +262,12 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-01-30T18:11:38.164101712Z",
-     "start_time": "2024-01-30T18:11:38.106695007Z"
+     "end_time": "2024-03-13T07:56:17.590902Z",
+     "start_time": "2024-03-13T07:56:17.583884Z"
     }
    },
    "id": "f554b02d92aa8091",
-   "execution_count": 32
+   "execution_count": 5
   },
   {
    "cell_type": "markdown",
@@ -290,7 +290,7 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "> **Result:**\n> `{'openassetio-mediacreation:color.OCIOColorManaged', 'openassetio-mediacreation:twoDimensional.PixelBased', 'openassetio-mediacreation:managementPolicy.Managed', 'openassetio-mediacreation:content.LocatableContent'}`"
+      "text/markdown": "> **Result:**\n> `{'openassetio-mediacreation:content.LocatableContent', 'openassetio-mediacreation:color.OCIOColorManaged', 'openassetio-mediacreation:twoDimensional.PixelBased', 'openassetio-mediacreation:managementPolicy.Managed'}`"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -307,12 +307,12 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-01-30T18:11:38.164577993Z",
-     "start_time": "2024-01-30T18:11:38.149463152Z"
+     "end_time": "2024-03-13T07:56:17.596280Z",
+     "start_time": "2024-03-13T07:56:17.591911Z"
     }
    },
    "id": "15e1be1277309b62",
-   "execution_count": 33
+   "execution_count": 6
   },
   {
    "cell_type": "markdown",
@@ -331,7 +331,7 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "> **Result:**\n> `{'openassetio-mediacreation:color.OCIOColorManaged', 'openassetio-mediacreation:content.LocatableContent', 'openassetio-mediacreation:managementPolicy.Managed'}`"
+      "text/markdown": "> **Result:**\n> `{'openassetio-mediacreation:color.OCIOColorManaged', 'openassetio-mediacreation:managementPolicy.Managed', 'openassetio-mediacreation:content.LocatableContent'}`"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -345,12 +345,12 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-01-30T18:11:38.164953871Z",
-     "start_time": "2024-01-30T18:11:38.149610878Z"
+     "end_time": "2024-03-13T07:56:17.601397Z",
+     "start_time": "2024-03-13T07:56:17.597131Z"
     }
    },
    "id": "8059d9533bf54deb",
-   "execution_count": 34
+   "execution_count": 7
   },
   {
    "cell_type": "markdown",
@@ -373,7 +373,7 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "> **Result:**\n> `{'openassetio-mediacreation:managementPolicy.Managed', 'openassetio-mediacreation:content.LocatableContent'}`"
+      "text/markdown": "> **Result:**\n> `{'openassetio-mediacreation:content.LocatableContent', 'openassetio-mediacreation:managementPolicy.Managed'}`"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -388,12 +388,12 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-01-30T18:11:38.214093687Z",
-     "start_time": "2024-01-30T18:11:38.149684272Z"
+     "end_time": "2024-03-13T07:56:17.607209Z",
+     "start_time": "2024-03-13T07:56:17.602157Z"
     }
    },
    "id": "ed1fb267bbf648ae",
-   "execution_count": 35
+   "execution_count": 8
   },
   {
    "cell_type": "markdown",
@@ -527,12 +527,12 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-01-30T18:11:38.214899040Z",
-     "start_time": "2024-01-30T18:11:38.197534761Z"
+     "end_time": "2024-03-13T07:56:17.648865Z",
+     "start_time": "2024-03-13T07:56:17.608546Z"
     }
    },
    "id": "4b129ad13007c541",
-   "execution_count": 36
+   "execution_count": 9
   }
  ],
  "metadata": {

--- a/examples/resources/management_policies/bal_database.json
+++ b/examples/resources/management_policies/bal_database.json
@@ -36,10 +36,12 @@
             "openassetio-mediacreation:content.LocatableContent": {
               "location": "file:///mnt/staging/renders/myrender.exr"
             }
-          },
-          "supported_access_modes": ["managerDriven"]
+          }
         }
-      ]
+      ],
+      "overrideByAccess": {
+        "read": null
+      }
     }
   }
 }


### PR DESCRIPTION
GitHub's `macos-latest` runner is now ARM based. Until we build ARM wheels for the `openassetio` MacOS package, we must downgrade the runner to an x86 machine.

Also, BAL was updated and the `managementPolicy` notebook no longer worked. This was fixed as a ninja commit in #69, but at time of writing has still not been merged. So cherry-pick the fix from there.