### PR TITLE
[Release] Bump version to v1.0.0-alpha.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openassetio-mediacreation"
-version = "1.0.0a10"
+version = "1.0.0a11"
 requires-python = ">=3.10"
 dependencies = ["openassetio>=1.0.0b2"]
 


### PR DESCRIPTION
Closes #107. Re-release commit due to missed pyproject version bump.