### PR TITLE
Bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build wheels
         run: pip wheel --no-deps --wheel-dir wheelhouse .
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: openassetio-mediacreation-wheels
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
GitHub has now removed `actions/upload-artifact` v3. See OpenAssetIO/OpenAssetIO#1444 for more info on consequences.

However, luckily in this repo we don't require significant changes.